### PR TITLE
implemented inline method: --exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ $ tac /etc/passwd | tac       #→ --file /etc/passwd
 $ cat /etc/passwd             #→ --egrep ^root:
 $ echo $((2 + 10))            #→ --regex ^\d+$
 $ pwd                         #→ --eval echo $PWD
+$ make test                   #→ --exit 0
 ```
 
 * Using `#→ --lines` the test will pass if the command output has
@@ -237,6 +238,10 @@ $ pwd                         #→ --eval echo $PWD
   same output. Useful to expand variables which store the full or
   partial output.
 
+* Using `#→ --exit` the test will pass if the exit code of the command
+  is equal to the code specified. Useful when testing commands that generate
+  variable output (or not output at all), and the exit code is the best 
+  indication of the result.
 
 ## Options
 
@@ -324,8 +329,6 @@ Example:
   aliases and functions will persist between tests.
 
 * Both STDIN and STDOUT are catch, you can also test error messages.
-
-* To test the exit code, just add a `;echo $?` after the command.
 
 * Use an empty `$` prompt to close the last command output.
 

--- a/clitest
+++ b/clitest
@@ -355,6 +355,7 @@ tt_run_test ()
 
 	# Execute the test command, saving output (STDOUT and STDERR)
 	eval "$tt_test_command" > "$tt_test_output_file" 2>&1
+	tt_exit_code=$?
 
 	#tt_debug OUTPUT "$(cat "$tt_test_output_file")"
 
@@ -442,6 +443,12 @@ tt_run_test ()
 				;;
 			esac
 		;;
+		exit)
+			test "$tt_exit_code" -eq "$tt_test_inline"
+			tt_test_status=$?
+			tt_test_diff="Command exited $tt_exit_code, but the expected exit code was $tt_test_inline"
+		;;
+
 		*)
 			tt_error "unknown test mode '$tt_test_mode'"
 		;;
@@ -565,6 +572,10 @@ tt_process_test_file ()
 							tt_test_inline=${tt_test_inline#--text }
 							tt_test_mode='text'
 						;;
+						'--exit '*)
+							tt_test_inline=${tt_test_inline#--exit }
+							tt_test_mode='exit'
+						;;
 						*)
 							tt_test_mode='text'
 						;;
@@ -573,11 +584,11 @@ tt_process_test_file ()
 					#tt_debug OK_TEXT "$tt_test_inline"
 
 					# There must be a number in --lines
-					if test "$tt_test_mode" = 'lines'
+					if test "$tt_test_mode" = 'lines' || test "$tt_test_mode" = 'exit'
 					then
 						case "$tt_test_inline" in
 							'' | *[!0-9]*)
-								tt_error "--lines requires a number. See line $tt_line_number of $tt_test_file"
+								tt_error "--$tt_test_mode requires a number. See line $tt_line_number of $tt_test_file"
 							;;
 						esac
 					fi

--- a/dev/test/inline-exit-error-1.sh
+++ b/dev/test/inline-exit-error-1.sh
@@ -1,0 +1,1 @@
+$ /bin/true                     #→ --exit 1

--- a/dev/test/inline-exit-error-2.sh
+++ b/dev/test/inline-exit-error-2.sh
@@ -1,0 +1,1 @@
+$ /bin/false                    #→ --exit 0

--- a/dev/test/inline-exit.sh
+++ b/dev/test/inline-exit.sh
@@ -1,0 +1,9 @@
+# Inline matching method: --exit
+# Matches the exit code of the command. It should be exactly equal to
+# the code specified inline.
+
+$ /bin/true                     #→ --exit 0
+$ /bin/false                    #→ --exit 1
+$ /bin/sh -c 'exit 2'           #→ --exit 2
+$ /bin/sh -c 'exit 3'           #→ --exit 3
+$ /bin/sh -c 'exit 4'           #→ --exit 4


### PR DESCRIPTION
A more standard way to match the exit code of commands. Useful for
commands that return variable output, or no output at all. In case of
failure it returns the specific message noting the exit codes.