### PR TITLE
Improve temporary dir creation

### DIFF
--- a/clitest
+++ b/clitest
@@ -62,12 +62,6 @@ Customization options:
       --prefix PREFIX         Set command line prefix (default: '$tt_prefix')
       --prompt STRING         Set prompt string (default: '$tt_prompt')"
 
-# Temporary files (using files because <(...) is not portable)
-tt_temp_dir="${TMPDIR:-/tmp}/clitest.$$"
-tt_temp_file="$tt_temp_dir/temp.txt"
-tt_test_ok_file="$tt_temp_dir/ok.txt"
-tt_test_output_file="$tt_temp_dir/output.txt"
-
 # Flags (0=off, 1=on), most can be altered by command line options
 tt_debug=0
 tt_use_colors=0
@@ -604,9 +598,28 @@ tt_process_test_file ()
     # Run pending tests
     test -n "$tt_test_command" && tt_run_test
 }
+tt_make_temp_dir ()
+{
+    # Create private temporary dir and sets global $tt_temp_dir.
+    # http://mywiki.wooledge.org/BashFAQ/062
+    
+    # Prefer mktemp when available
+    tt_temp_dir=$(mktemp -d "${TMPDIR:-/tmp}/clitest.XXXXXX" 2> /dev/null) && return 0
+    
+    # No mktemp, let's create the dir manually
+    tt_temp_dir="${TMPDIR:-/tmp}/clitest.$(awk 'BEGIN { srand(); print rand() }').$$" &&
+        mkdir -m 700 "$tt_temp_dir" || tt_error "cannot create temporary dir: $tt_temp_dir"
+}
 
 
 ### Init process
+
+# Temporary files (using files because <(...) is not portable)
+tt_temp_dir=
+tt_make_temp_dir  # sets global $tt_temp_dir
+tt_temp_file="$tt_temp_dir/temp.txt"
+tt_test_ok_file="$tt_temp_dir/ok.txt"
+tt_test_output_file="$tt_temp_dir/output.txt"
 
 # Handle command line options
 while test "${1#-}" != "$1"
@@ -756,9 +769,6 @@ if test $? -ne 0
 then
     tt_error "invalid argument for -s or --skip: $tt_skip_range"
 fi
-
-# Create temp dir, protected from others
-umask 077 && mkdir "$tt_temp_dir" || tt_error "cannot create temporary dir: $tt_temp_dir"
 
 
 ### Real execution begins here

--- a/test.md
+++ b/test.md
@@ -47,8 +47,8 @@ $ echo $not_exported  #→ --regex ^1$
 $ TMPDIR___SAVE="$TMPDIR"
 $ TMPDIR=/XXnotfoundXX
 $ export TMPDIR
-$ ./clitest test/ok-1.sh 2>&1 | grep ^clitest | sed 's/clitest\.[0-9]*$/clitest.NNN/'
-clitest: Error: cannot create temporary dir: /XXnotfoundXX/clitest.NNN
+$ ./clitest test/ok-1.sh 2>&1 | grep ^clitest | sed 's/clitest\..*$/clitest.XXXXXX/'
+clitest: Error: cannot create temporary dir: /XXnotfoundXX/clitest.XXXXXX
 $ TMPDIR="$TMPDIR___SAVE"
 $
 ```


### PR DESCRIPTION
Use `mktemp`. If not available, create a random dir manually, using awk's `rand()` and `$$`.

Not a pretty solution, but it's portable.

Fixes #12