### PR TITLE
CI: Disable OS X builds for now, too slow

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: bash
 
 os:
   - linux
-  - osx
+  # - osx  # >30min to process :(
 
 # Prepare the environment
 addons:


### PR DESCRIPTION
It is taking more than 30 minutes waiting to start :(

https://travis-ci.org/aureliojargas/clitest/builds/172356573