### PR TITLE
Use ENTRYPOINT to make container behave as an executable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,5 @@ COPY clitest test.md /clitest/
 COPY test/ /clitest/test/
 RUN ln -s /clitest/clitest /usr/local/bin/clitest
 
-CMD ["clitest", "--help"]
+ENTRYPOINT ["clitest"]
+CMD ["--help"]

--- a/README-docker.md
+++ b/README-docker.md
@@ -42,19 +42,19 @@ $
 To run clitest on your own test files, map their directory with `-v`. For example, mapping the current directory to container's `/src` and testing the `test.md` file:
 
 ```
-docker run --rm -v "$PWD:/src/" aureliojargas/clitest clitest /src/test.md
+docker run --rm -v "$PWD:/src/" aureliojargas/clitest /src/test.md
 ```
 
 Same as before, but this time using `-w` to set the current directory to `/src`, making sure the execution happens inside your directory:
 
 ```
-docker run --rm -v "$PWD:/src/" -w /src aureliojargas/clitest clitest test.md
+docker run --rm -v "$PWD:/src/" -w /src aureliojargas/clitest test.md
 ```
 
 If you don't have any test files right now, you can see clitest in action by running its own test suite:
 
 ```console
-$ docker run --rm -w /clitest aureliojargas/clitest clitest test.md
+$ docker run --rm -w /clitest aureliojargas/clitest test.md
 #1    test -f ./clitest; echo $?
 #2    test -d ./test/; echo $?
 #3    COLUMNS=80


### PR DESCRIPTION
clitest is now the default command when running this image.

You can pass aditional options and files in `docker run`:

    docker run --rm aureliojargas/clitest test.md

If you need to enter the container shell, use:

    docker run --rm -it --entrypoint /bin/sh aureliojargas/clitest