### PR TITLE
Add Makefile, use Docker for lint/test/CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,31 +1,9 @@
 language: bash
 
-os:
-  - linux
-  # - osx  # >30min to process :(
-
-# Prepare the environment
-addons:
-  apt:
-    packages:
-      # Linux: only bash (and sh) are installed by default
-      - ksh
-      - zsh
-      # Linux: install the checkbashisms script
-      - devscripts
-before_install:
-  # OS X: install the dash and checkbashisms script
-  - if test "$TRAVIS_OS_NAME" = osx; then brew update && brew install dash checkbashisms; fi
-
 script:
-  # Run some code checkings on the script itself
-  - checkbashisms --posix clitest
-  # Run the full test suite in all the supported POSIX shells
-  - bash clitest test.md
-  - dash clitest test.md
-  - ksh  clitest test.md
-  - zsh  clitest test.md
-  - sh   clitest test.md
+  - make docker-build
+  - make lint
+  - make test
 
 notifications:
   email: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,11 @@
 FROM alpine:3.11
 
 # Perl is required by clitest's --regex matching mode
-RUN apk --no-cache add perl
+RUN apk --no-cache add \
+    bash dash mksh zsh \
+    perl \
+    make \
+    checkbashisms
 
 COPY clitest test.md /clitest/
 COPY test/ /clitest/test/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-FROM alpine:3.7
-
-MAINTAINER Aurelio Jargas <verde@aurelio.net>
+FROM alpine:3.11
 
 # Perl is required by clitest's --regex matching mode
 RUN apk --no-cache add perl

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,4 @@ COPY clitest test.md /clitest/
 COPY test/ /clitest/test/
 RUN ln -s /clitest/clitest /usr/local/bin/clitest
 
-ENTRYPOINT ["clitest"]
-CMD ["--help"]
+WORKDIR /clitest

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+# Developer workflow: run locally the same commands Travis will run in
+# the CI. See the .travis.yml file for the list of commands.
+#
+# By default, the linting and testing targets are run inside the clitest
+# Docker container. To run them directly on the host, avoiding the
+# container, unset the `docker_run` variable. Examples:
+#
+#    make test-bash                # test using container's bash
+#    make test-bash docker_run=    # test using host's bash
+
+docker_image = aureliojargas/clitest
+docker_run = docker run --rm -it -v $$PWD:/clitest $(docker_image)
+test_cmd = clitest --first --progress none test.md
+
+default:
+	@echo "Read the comments in the Makefile for help"
+
+lint:
+	$(docker_run) checkbashisms --posix clitest
+
+test: test-bash test-dash test-mksh test-sh test-zsh
+test-%:
+	$(docker_run) $* $(test_cmd)
+
+docker-build:
+	docker build -t $(docker_image) .
+
+docker-run:
+	$(docker_run) $(cmd)

--- a/README-docker.md
+++ b/README-docker.md
@@ -10,10 +10,10 @@ docker pull aureliojargas/clitest
 
 ## Initial run
 
-For the available clitest options, just run the image with no arguments:
+For the available clitest options, just run the image with the command `clitest --help`:
 
 ```console
-$ docker run --rm aureliojargas/clitest
+$ docker run --rm aureliojargas/clitest clitest --help
 Usage: clitest [options] <file ...>
 
 Options:
@@ -42,19 +42,19 @@ $
 To run clitest on your own test files, map their directory with `-v`. For example, mapping the current directory to container's `/src` and testing the `test.md` file:
 
 ```
-docker run --rm -v "$PWD:/src/" aureliojargas/clitest /src/test.md
+docker run --rm -t -v "$PWD:/src/" aureliojargas/clitest clitest /src/test.md
 ```
 
 Same as before, but this time using `-w` to set the current directory to `/src`, making sure the execution happens inside your directory:
 
 ```
-docker run --rm -v "$PWD:/src/" -w /src aureliojargas/clitest test.md
+docker run --rm -t -v "$PWD:/src/" -w /src aureliojargas/clitest clitest test.md
 ```
 
 If you don't have any test files right now, you can see clitest in action by running its own test suite:
 
 ```console
-$ docker run --rm -w /clitest aureliojargas/clitest test.md
+$ docker run --rm -t -w /clitest aureliojargas/clitest clitest test.md
 #1    test -f ./clitest; echo $?
 #2    test -d ./test/; echo $?
 #3    COLUMNS=80
@@ -70,6 +70,8 @@ $ docker run --rm -w /clitest aureliojargas/clitest test.md
 OK: 265 of 265 tests passed
 $
 ```
+
+Make sure to use `-t` in `docker run` to get colors in clitest output.
 
 ## Build
 

--- a/README-docker.md
+++ b/README-docker.md
@@ -42,19 +42,19 @@ $
 To run clitest on your own test files, map their directory with `-v`. For example, mapping the current directory to container's `/src` and testing the `test.md` file:
 
 ```
-docker run --rm -t -v "$PWD:/src/" aureliojargas/clitest clitest /src/test.md
+docker run --rm -v "$PWD:/src/" aureliojargas/clitest clitest /src/test.md
 ```
 
 Same as before, but this time using `-w` to set the current directory to `/src`, making sure the execution happens inside your directory:
 
 ```
-docker run --rm -t -v "$PWD:/src/" -w /src aureliojargas/clitest clitest test.md
+docker run --rm -v "$PWD:/src/" -w /src aureliojargas/clitest clitest test.md
 ```
 
 If you don't have any test files right now, you can see clitest in action by running its own test suite:
 
 ```console
-$ docker run --rm -t -w /clitest aureliojargas/clitest clitest test.md
+$ docker run --rm -w /clitest aureliojargas/clitest clitest test.md
 #1    test -f ./clitest; echo $?
 #2    test -d ./test/; echo $?
 #3    COLUMNS=80
@@ -71,14 +71,12 @@ OK: 265 of 265 tests passed
 $
 ```
 
-Make sure to use `-t` in `docker run` to get colors in clitest output.
-
 ## Build
 
 To build this image, go to clitest repository root and run:
 
 ```
-docker build -t aureliojargas/clitest .
+make docker-build
 ```
 
 

--- a/test.md
+++ b/test.md
@@ -22,6 +22,8 @@ $
 Set a default terminal width of 80 columns. It's used by separator lines.
 
 ```
+$ shopt -u checkwinsize 2> /dev/null  # bash: disable automatic check
+$ unset COLUMNS  # mksh: first unset, then one can manually set it
 $ COLUMNS=80
 $ export COLUMNS
 $


### PR DESCRIPTION
Instead of installing dependencies in both the local machine and in
Travis runner, install everything inside the clitest Docker image:

- Supported shells: bash, dash, mksh, zsh
- Linter: checkbashisms

Also updated Alpine version from 3.7 to 3.11.

The image size grew from ~40MB to ~60MB.

The Docker container is not using ENTRYPOINT anymore, to make it easier
to run arbitrary commands inside it. So now you have to explicitly run
the clitest command.

Add a Makefile to isolate all the commands related to dev tasks such as
running linters and tests. Note that by default all those tasks are run
inside the clitest Docker container. To run them directly on the host,
avoiding the container, unset the `docker_run` variable. Examples:

    make test-bash               # test using container's bash
    make test-bash docker_run=   # test using host's bash

The CI configuration (Travis) was updated to avoid installing
dependencies and to run make targets inside a freshly built Docker
container.

Also fixed the `COLUMNS` handling in the tests, so it is compatible with
bash and mksh running inside the container.