### PR TITLE
Input file: support reading from stdin, symlinks, others

### DIFF
--- a/clitest
+++ b/clitest
@@ -786,6 +786,12 @@ do
     # to preserve the relative paths of the input files
     cd "$tt_original_dir"
 
+    # Abort when test file is a directory
+    if test -d "$tt_test_file"
+    then
+        tt_error "input file is a directory: $tt_test_file"
+    fi
+
     # Abort when test file not found/readable
     if test ! -f "$tt_test_file" || test ! -r "$tt_test_file"
     then

--- a/clitest
+++ b/clitest
@@ -617,6 +617,7 @@ tt_make_temp_dir ()
 tt_temp_dir=
 tt_make_temp_dir  # sets global $tt_temp_dir
 tt_temp_file="$tt_temp_dir/temp.txt"
+tt_stdin_file="$tt_temp_dir/stdin.txt"
 tt_test_ok_file="$tt_temp_dir/ok.txt"
 tt_test_output_file="$tt_temp_dir/output.txt"
 
@@ -653,7 +654,7 @@ do
             break
         ;;
         -)
-            # Argument - means "read from STDIN" (not supported)
+            # Argument - means "read test file from STDIN"
             break
         ;;
         *)
@@ -785,6 +786,13 @@ do
     # Some tests may 'cd' to another dir, we need to get back
     # to preserve the relative paths of the input files
     cd "$tt_original_dir"
+
+    # Support using '-' to read the test file from STDIN
+    if test "$tt_test_file" = '-'
+    then
+        tt_test_file="$tt_stdin_file"
+        cat > "$tt_test_file"
+    fi
 
     # Abort when test file is a directory
     if test -d "$tt_test_file"

--- a/clitest
+++ b/clitest
@@ -793,7 +793,7 @@ do
     fi
 
     # Abort when test file not found/readable
-    if test ! -f "$tt_test_file" || test ! -r "$tt_test_file"
+    if test ! -r "$tt_test_file"
     then
         tt_error "cannot read input file: $tt_test_file"
     fi

--- a/test.md
+++ b/test.md
@@ -2121,12 +2121,23 @@ clitest: Error: cannot read input file: -
 $
 ```
 
-## Read test file from STDIN (not supported)
+## Read test file from /dev/stdin
 
 ```
-$ cat test/ok-1.sh | ./clitest /dev/stdin; echo $?
-clitest: Error: cannot read input file: /dev/stdin
-2
+$ cat test/ok-1.sh | ./clitest /dev/stdin
+#1	echo ok
+OK: 1 of 1 test passed
+$
+```
+
+## Test file is a symlink
+
+```
+$ ln -s test/ok-1.sh testsymlink
+$ ./clitest testsymlink
+#1	echo ok
+OK: 1 of 1 test passed
+$ rm testsymlink
 $
 ```
 

--- a/test.md
+++ b/test.md
@@ -76,12 +76,18 @@ File not found
 $ ./clitest notfound; echo $?
 clitest: Error: cannot read input file: notfound
 2
+$
+```
+
+File is a directory
+
+```
 $ ./clitest .
-clitest: Error: cannot read input file: .
+clitest: Error: input file is a directory: .
 $ ./clitest ./
-clitest: Error: cannot read input file: ./
+clitest: Error: input file is a directory: ./
 $ ./clitest /etc
-clitest: Error: cannot read input file: /etc
+clitest: Error: input file is a directory: /etc
 $
 ```
 
@@ -183,8 +189,8 @@ $
 ## Option --quiet has no effect in error messages
 
 ```
-$ ./clitest --quiet /etc
-clitest: Error: cannot read input file: /etc
+$ ./clitest --quiet notfound
+clitest: Error: cannot read input file: notfound
 $
 ```
 

--- a/test.md
+++ b/test.md
@@ -2110,14 +2110,16 @@ clitest: Error: cannot read input file: --quiet
 $
 ```
 
-## File - meaning STDIN (not supported)
+## File - meaning STDIN
 
 ```
 $ cat test/ok-1.sh | ./clitest -
-clitest: Error: cannot read input file: -
+#1	echo ok
+OK: 1 of 1 test passed
 $ cat test/ok-1.sh | ./clitest -- -; echo $?
-clitest: Error: cannot read input file: -
-2
+#1	echo ok
+OK: 1 of 1 test passed
+0
 $
 ```
 


### PR DESCRIPTION
Previously, clitest only accepted the input file if it was a "normal"
(as in `test -f`) file. But that's too restrictive, for no reason. At
the end, it doesn't matter if it is a normal or a special file, what
matters is that it is readable and we can find the tests on it.

With those changes, now the input file can be:

- A normal file
- A symlink that points to a file
- `/dev/stdin` in systems that support it
- `-` as a shortcut to stdin

Reading from directories continues to be forbidden (we can't properly
identify clitest input files), but at least now the error message is
more clear that it is a directory.

Issue #32