### PR TITLE
Simplify reverse range handling

### DIFF
--- a/clitest
+++ b/clitest
@@ -213,7 +213,7 @@ tt_parse_range ()  # $1=range
     tt_part=
     tt_n1=
     tt_n2=
-    tt_operation=
+    tt_swap=
     tt_range_data=':'  # :1:2:4:7:
 
     # Loop each component: a number or a range
@@ -228,17 +228,19 @@ tt_parse_range ()  # $1=range
                 tt_n1=${tt_part%-*}
                 tt_n2=${tt_part#*-}
 
-                tt_operation='+'
-                test "$tt_n1" -gt "$tt_n2" && tt_operation='-'
+                # Negative range, let's just reverse it (5-1 => 1-5)
+                if test "$tt_n1" -gt "$tt_n2"
+                then
+                    tt_swap=$tt_n1
+                    tt_n1=$tt_n2
+                    tt_n2=$tt_swap
+                fi
 
                 # Expand the range (1-4 => 1:2:3:4)
                 tt_part=$tt_n1:
                 while test "$tt_n1" -ne "$tt_n2"
                 do
-                    # Math operator in a variable drives shellcheck crazy
-                    # https://github.com/koalaman/shellcheck/issues/2000
-                    # shellcheck disable=SC1102
-                    tt_n1=$((tt_n1 $tt_operation 1))
+                    tt_n1=$((tt_n1 + 1))
                     tt_part=$tt_part$tt_n1:
                 done
                 tt_part=${tt_part%:}

--- a/test.md
+++ b/test.md
@@ -736,6 +736,17 @@ $ ./clitest --list-run -t 3,5-7 test/ok-10.sh
 $
 ```
 
+Reverse ranges and repeated numbers are supported
+
+```
+$ ./clitest --list -t 3,7-5,3,6,5 test/ok-10.sh
+#3	echo 3 
+#5	echo 5 
+#6	echo 6 
+#7	echo 7 
+$
+```
+
 Using `-t` to limit to a range and the `-s` exclude some more
 
 ```


### PR DESCRIPTION
Using a variable as the arithmetic operator works in the supported
shells, but it breaks both shellcheck and shfmt:

- https://github.com/koalaman/shellcheck/issues/2000
- https://github.com/mvdan/sh/issues/583

The new code is more straightforward and has no issues.