### PR TITLE
Abort when --post-flight command fails

### DIFF
--- a/clitest
+++ b/clitest
@@ -874,7 +874,8 @@ tt_clean_up
 
 # Some clean up command to run after all the tests?
 if test -n "$tt_post_command"; then
-    eval "$tt_post_command"
+    eval "$tt_post_command" ||
+        tt_error "post-flight command failed with status=$?: $tt_post_command"
 fi
 
 #-----------------------------------------------------------------------

--- a/test.md
+++ b/test.md
@@ -2093,6 +2093,10 @@ FAIL: 50 of 50 tests failed
 $ ./clitest --pre-flight 'false' test/ok-1.sh; echo $?
 clitest: Error: pre-flight command failed with status=1: false
 2
+$ ./clitest --post-flight 'false' test/ok-1.sh; echo $?
+#1	echo ok
+clitest: Error: post-flight command failed with status=1: false
+2
 $
 ```
 


### PR DESCRIPTION
Previously, any error when running the `--post-flight` command was
ignored. The rationale was that all the "real" tests were already
executed, being the post-flight a mere non-fatal cleanup action.

Now any failure in that step is fatal.
Just like it already is with `--pre-flight`.

The user specifically asked for a cleanup task to be run, and should be
notified on any error during its execution. If this is an optional task
for the user, he/she can just add a `|| true` at the end so that it
always succeeds, even in case of errors.