### PR TITLE
implement STDIN isolation among tests

### DIFF
--- a/clitest
+++ b/clitest
@@ -301,7 +301,7 @@ tt_run_test() {
     #tt_debug EVAL "$tt_test_command"
 
     # Execute the test command, saving output (STDOUT and STDERR)
-    eval "$tt_test_command" > "$tt_test_output_file" 2>&1
+    eval "$tt_test_command" > "$tt_test_output_file" 2>&1 < /dev/null
     tt_test_exit_code=$?
 
     #tt_debug OUTPUT "$(cat "$tt_test_output_file")"

--- a/test.md
+++ b/test.md
@@ -52,9 +52,9 @@ from STDIN. This was reported on issue #42 on Github.
 Testing for a regression.
 
 ```
-$ echo testing stdin isolation. Will read make next test to fail? ; read asdf
+$ echo testing stdin isolation. Will read make next test to fail? ; read stdin_isolation
 testing stdin isolation. Will read make next test to fail?
-$ echo does this fail or succeed? If succeeds, stdin isolation is working.  Otherwise, not.
+$ echo does this fail or succeed? If succeeds, stdin isolation is working.  Otherwise, not. ; unset stdin_isolation
 does this fail or succeed? If succeeds, stdin isolation is working. Otherwise, not.
 $
 ```

--- a/test.md
+++ b/test.md
@@ -43,22 +43,6 @@ $ echo $not_exported  #=> 1
 $ echo $not_exported  #=> --regex ^1$
 ```
 
-## Is STDIN isolated?
-
-This was a bug found on early versions of clitest in which tests shared STDIN
-with clitest and with each other, causing unexpected results when a test read
-from STDIN. This was reported on issue #42 on Github.
-
-Testing for a regression.
-
-```
-$ echo testing stdin isolation ; read stdin_isolation
-testing stdin isolation
-$ echo Succeed\? If so, stdin isolation works. ; unset stdin_isolation
-Succeed? If so, stdin isolation works.
-$
-```
-
 ## Check the temporary dir creation
 
 ```
@@ -2204,6 +2188,14 @@ $ ./clitest test/stdout-stderr.sh
 #9	./clitest notfound 2> /dev/null
 #10	./clitest notfound > /dev/null 2>&1
 OK: 10 of 10 tests passed
+$
+```
+
+STDIN Isolation
+
+```
+$ ./clitest --quiet test/stdin-isolation.sh ; echo $?
+0
 $
 ```
 

--- a/test.md
+++ b/test.md
@@ -52,10 +52,10 @@ from STDIN. This was reported on issue #42 on Github.
 Testing for a regression.
 
 ```
-$ echo testing stdin isolation. Will read make next test to fail\? ; read stdin_isolation
-testing stdin isolation. Will read make next test to fail?
-$ echo does this fail or succeed\? If succeeds, stdin isolation is working.  Otherwise, not. ; unset stdin_isolation
-does this fail or succeed? If succeeds, stdin isolation is working. Otherwise, not.
+$ echo testing stdin isolation ; read stdin_isolation
+testing stdin isolation
+$ echo Succeed\? If so, stdin isolation works. ; unset stdin_isolation
+Succeed? If so, stdin isolation works.
 $
 ```
 

--- a/test.md
+++ b/test.md
@@ -43,6 +43,22 @@ $ echo $not_exported  #=> 1
 $ echo $not_exported  #=> --regex ^1$
 ```
 
+## Is STDIN isolated?
+
+This was a bug found on early versions of clitest in which tests shared STDIN
+with clitest and with each other, causing unexpected results when a test read
+from STDIN. This was reported on issue #42 on Github.
+
+Testing for a regression.
+
+```
+$ echo testing stdin isolation. Will read make next test to fail? ; read
+testing stdin isolation. Will read make next test to fail?
+$ echo does this fail or succeed? If succeeds, stdin isolation is working.  Otherwise, not.
+does this fail or succeed? If succeeds, stdin isolation is working. Otherwise, not.
+$
+```
+
 ## Check the temporary dir creation
 
 ```

--- a/test.md
+++ b/test.md
@@ -52,7 +52,7 @@ from STDIN. This was reported on issue #42 on Github.
 Testing for a regression.
 
 ```
-$ echo testing stdin isolation. Will read make next test to fail? ; read
+$ echo testing stdin isolation. Will read make next test to fail? ; read asdf
 testing stdin isolation. Will read make next test to fail?
 $ echo does this fail or succeed? If succeeds, stdin isolation is working.  Otherwise, not.
 does this fail or succeed? If succeeds, stdin isolation is working. Otherwise, not.

--- a/test.md
+++ b/test.md
@@ -52,9 +52,9 @@ from STDIN. This was reported on issue #42 on Github.
 Testing for a regression.
 
 ```
-$ echo testing stdin isolation. Will read make next test to fail? ; read stdin_isolation
+$ echo testing stdin isolation. Will read make next test to fail\? ; read stdin_isolation
 testing stdin isolation. Will read make next test to fail?
-$ echo does this fail or succeed? If succeeds, stdin isolation is working.  Otherwise, not. ; unset stdin_isolation
+$ echo does this fail or succeed\? If succeeds, stdin isolation is working.  Otherwise, not. ; unset stdin_isolation
 does this fail or succeed? If succeeds, stdin isolation is working. Otherwise, not.
 $
 ```

--- a/test/stdin-isolation.sh
+++ b/test/stdin-isolation.sh
@@ -1,0 +1,12 @@
+#
+# This was a bug found on early versions of clitest in which tests shared
+# STDIN with clitest and with each other, causing unexpected results when
+# a test read from STDIN. This was reported on issue #42 on Github.
+#
+# Testing for a regression. 
+#
+
+$ echo testing stdin isolation ; read stdin_isolation
+testing stdin isolation
+$ echo Failed\? Regression to stdin isolation added. ; unset stdin_isolation
+Failed? Regression to stdin isolation added.


### PR DESCRIPTION
Isolate STDIN among tests and among a test and clitest itself.

This fixes the bug reported on issue #42 in which tests and clitest share STDIN,
causing unexpected results when the command specified on a test reads from
STDIN.