### PR TITLE
Fix leftover temporary directories

### DIFF
--- a/clitest
+++ b/clitest
@@ -590,14 +590,6 @@ tt_make_temp_dir() {
 
 ### Init process
 
-# Temporary files (using files because <(...) is not portable)
-tt_temp_dir=
-tt_make_temp_dir  # sets global $tt_temp_dir
-tt_temp_file="$tt_temp_dir/temp.txt"
-tt_stdin_file="$tt_temp_dir/stdin.txt"
-tt_test_ok_file="$tt_temp_dir/ok.txt"
-tt_test_output_file="$tt_temp_dir/output.txt"
-
 # Handle command line options
 while test "${1#-}" != "$1"; do
     case "$1" in
@@ -797,6 +789,14 @@ if test $? -ne 0; then
 fi
 
 ### Real execution begins here
+
+# Temporary files (using files because <(...) is not portable)
+tt_temp_dir=
+tt_make_temp_dir  # sets global $tt_temp_dir
+tt_temp_file="$tt_temp_dir/temp.txt"
+tt_stdin_file="$tt_temp_dir/stdin.txt"
+tt_test_ok_file="$tt_temp_dir/ok.txt"
+tt_test_output_file="$tt_temp_dir/output.txt"
 
 # Some preparing command to run before all the tests?
 if test -n "$tt_pre_command"; then


### PR DESCRIPTION
Clitest leaves a few leftover temp directories when run, in some conditions.

Move the block of code that creates the temporary directory closer to the
point when the directory is actually used. It was being created too early,
making options like --help and --verbose to create directories unnecessarily
and leave leftovers.

Fixes issue #44 .