### PR TITLE
Add GitHub action

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -9,14 +9,23 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v7
       - run: make docker-build
       - run: make lint
 
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v7
       - run: make docker-build
       - run: make versions
       - run: make test
+
+  action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./
+        with:
+          files: examples/cut.txt examples/hello-world.txt
+          options: --first --progress none

--- a/README.md
+++ b/README.md
@@ -47,6 +47,28 @@ docker run --rm -t aureliojargas/clitest --help
 ```
 
 
+## GitHub Actions
+
+This repository doubles as a GitHub Action, so a workflow does not have to
+download and install the script itself:
+
+```yaml
+      - uses: actions/checkout@v7
+      - uses: aureliojargas/clitest@main
+        with:
+          files: examples/intro.txt
+```
+
+clitest runs on the runner rather than in a container, so the test files can
+invoke anything the job has already built or installed.
+
+| Input               | Description                                               | Default      |
+| ------------------- | --------------------------------------------------------- | ------------ |
+| `files`             | Test file(s) to run. Whitespace-separated, globs allowed. | *(required)* |
+| `options`           | Extra clitest options, e.g. `--first --prefix tab`        | *(none)*     |
+| `working-directory` | Directory to run clitest from                             | `.`          |
+
+
 ## Quick Intro
 
 Save the commands and their expected output in a text file:

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,33 @@
+# A composite action, not a Docker container action, so that clitest runs on
+# the runner itself and sees the same PATH, files and environment as the rest
+# of the job. Tests usually exercise something the workflow just built or
+# installed, which would be invisible from inside a container.
+name: clitest
+description: Test the Unix command lines documented in a file
+branding:
+  icon: check-square
+  color: green
+
+inputs:
+  files:
+    description: Test file(s) to run. Whitespace-separated, globs allowed.
+    required: true
+  options:
+    description: Extra clitest options, e.g. "--first --prefix tab"
+    required: false
+    default: ""
+  working-directory:
+    description: Directory to run clitest from
+    required: false
+    default: "."
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        clitest_files: ${{ inputs.files }}
+        clitest_options: ${{ inputs.options }}
+      # Unquoted on purpose: splits multiple options and files, expands globs
+      run: '"$GITHUB_ACTION_PATH/clitest" $clitest_options $clitest_files'


### PR DESCRIPTION
This allows to use `aureliojargas/clitest@0.6.0` in GitHub workflows without manual setup (like in https://github.com/JabRef/jabref/pull/16291)

I just put "@main" in the current example to enable use before a release.