### PR TITLE
Add Dependabot config for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference
+
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly


### PR DESCRIPTION
🤖 Keep the GitHub Actions used in CI up to date automatically.

## What

Adds `.github/dependabot.yml` with a single `github-actions` ecosystem entry, checked monthly.

## Why

`.github/workflows/check.yml` uses `actions/checkout@v2`, which runs on a deprecated Node runtime. Dependabot will open a PR to bump it and keep it current from now on, without anyone having to notice.

Scoped to GitHub Actions only — there are no package manifests to track, and the `Dockerfile.dev` base image is intentionally left out to keep the noise down.

## How to test

Merge and check the repo's Insights → Dependency graph → Dependabot tab; the `github-actions` entry should appear and the first run should propose the `actions/checkout` bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)