### PR TITLE
Adopt pre-commit to run linters and tests

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -10,7 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - run: make docker-build
       - run: make lint
       - run: make validate-docs
 
@@ -18,7 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - run: make docker-build
       - run: make versions
       - run: make test
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 .vscode
+
+# Dev-only empty file whose timestamp decides if the clitest-dev Docker image
+# should be built. Created and used by the Makefile targets.
+/.docker-build-done

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,25 @@
+default_install_hook_types: [pre-commit, pre-push]
+repos:
+  - repo: local
+    hooks:
+      - id: validate-docs
+        name: Validate docs
+        entry: make validate-docs
+        language: system
+        pass_filenames: false
+        files: ^(README\.md|examples/.*)$
+
+      - id: make-lint
+        name: make lint (takes a few seconds)
+        entry: make lint docker_tty=
+        language: system
+        pass_filenames: false
+        files: ^(Makefile|Dockerfile\.dev|clitest)$
+
+      - id: make-test
+        name: make test (takes a few minutes)
+        entry: make test docker_tty=
+        language: system
+        pass_filenames: false
+        files: ^(Makefile|Dockerfile\.dev|clitest|test\.md|test/.*)$
+        stages: [pre-push]  # run on push only, too much wait for every commit

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,5 +27,16 @@ For a quicker test using only a single shell:
 make test-bash  # takes less than a minute
 ```
 
+To execute those commands automatically when making commits or pushes, install
+[pre-commit][3] and run:
+
+```bash
+$ pre-commit install
+pre-commit installed at .git/hooks/pre-commit
+pre-commit installed at .git/hooks/pre-push
+$
+```
+
 [1]: https://github.com/aureliojargas/clitest/issues
 [2]: https://github.com/aureliojargas/clitest/pulls
+[3]: https://pre-commit.com

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,8 @@
 #    make test-bash docker_run=    # test using host's Bash
 
 docker_image = clitest-dev
-docker_run = docker run --rm -t -v $$PWD:/mnt $(docker_image)
+docker_tty = -t
+docker_run = docker run --rm $(docker_tty) -v $$PWD:/mnt $(docker_image)
 test_cmd = clitest --first --progress none
 
 default:

--- a/Makefile
+++ b/Makefile
@@ -8,26 +8,39 @@
 #
 #    make test-bash                # test using container's Bash
 #    make test-bash docker_run=    # test using host's Bash
+#
+# The clitest-dev Docker image will be built automatically on the first call to
+# a container target (e.g., make lint) and then reused for the next calls. The
+# image will be rebuilt when the `Dockerfile.dev` file changes or when the
+# `.docker-build-done` file is removed.
 
 docker_image = clitest-dev
 docker_tty = -t
 docker_run = docker run --rm $(docker_tty) -v $$PWD:/mnt $(docker_image)
 test_cmd = clitest --first --progress none
 
+# Set to `.docker-build-done` if $docker_run is non-empty, else leave empty
+ensure_docker_build = $(if $(strip $(docker_run)),.docker-build-done)
+
 default:
 	@echo "Read the comments in the Makefile for help"
 
-fmt:
+# Build if `Dockerfile.dev` file is newer than `.docker-build-done` file
+.docker-build-done: Dockerfile.dev
+	docker build -t $(docker_image) -f Dockerfile.dev .
+	@touch $@
+
+fmt: $(ensure_docker_build)
 	$(docker_run) shfmt -w -i 4 -ci -kp -sr clitest
 
-lint:
+lint: $(ensure_docker_build)
 	$(docker_run) shfmt -d -i 4 -ci -kp -sr clitest
 	$(docker_run) checkbashisms --posix clitest
 	$(docker_run) shellcheck clitest
 
 # Aliases in pre-flight are necessary because there's calls to `clitest` from
 # PATH in the documentation files.
-validate-docs:
+validate-docs: $(ensure_docker_build)
 	./$(test_cmd) --pre-flight 'alias clitest=./clitest' README.md
 	./$(test_cmd) \
 		examples/cut.txt \
@@ -37,14 +50,11 @@ validate-docs:
 	cd examples; ../$(test_cmd) --pre-flight 'alias clitest=../clitest' README.md
 
 test: test-bash test-dash test-mksh test-sh test-zsh
-test-%:
+test-%: $(ensure_docker_build)
 	$(docker_run) $* ./$(test_cmd) test.md
 
-versions:
+versions: $(ensure_docker_build)
 	@$(docker_run) sh -c 'apk list 2>/dev/null | cut -d " " -f 1 | sort'
 
-docker-build:
-	docker build -t $(docker_image) -f Dockerfile.dev .
-
-docker-run:
+docker-run: $(ensure_docker_build)
 	$(docker_run) $(cmd)


### PR DESCRIPTION
Run locally (and automatically, when needed) the same checks the CI will run.

