### PR TITLE
Adopt pre-commit-hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,13 @@
 default_install_hook_types: [pre-commit, pre-push]
 repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: check-yaml
+      - id: end-of-file-fixer
+        exclude: ^test/no-nl-file-[123]\.sh$
+      - id: mixed-line-ending
+
   - repo: local
     hooks:
       - id: validate-docs

--- a/test/inline-match-lines.sh
+++ b/test/inline-match-lines.sh
@@ -48,4 +48,3 @@ $ echo '--lines is cool'         #=> --text --lines is cool
 # $ echo 'fail'                 #=> --lines -1
 # $ echo 'fail'                 #=> --lines 1.0
 # $ echo 'fail'                 #=> --lines foo
-


### PR DESCRIPTION
These are the checks that make sense for this repository.

The `trailing-whitespace` check cannot be adopted because there's many tests that rely on trailing whitespace, because clitest keeps them in the original command lines.

Just one file needed fixing:

    $ pre-commit run -a
    check yaml....................................................Passed
    fix end of files..............................................Failed
    - hook id: end-of-file-fixer
    - exit code: 1
    - files were modified by this hook

    Fixing test/inline-match-lines.sh

    mixed line ending.............................................Passed