### PR TITLE
Support running clitest as a pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,8 @@
+# How to use it: https://github.com/aureliojargas/clitest#pre-commit-hook
+
+- id: clitest
+  name: clitest
+  description: Automatic testing in Unix command lines
+  entry: clitest
+  language: script
+  types: [text]

--- a/README.md
+++ b/README.md
@@ -44,6 +44,24 @@ You can also run clitest in a Docker container ([more info in Docker Hub](https:
 docker run --rm -t aureliojargas/clitest --help
 ```
 
+## Pre-commit hook
+
+clitest can be used as a [pre-commit](https://github.com/pre-commit/pre-commit) hook.
+Add this to your `.pre-commit-config.yaml`:
+
+```yaml
+- repo: https://github.com/aureliojargas/clitest
+  rev: 0.6.0
+  hooks:
+    - id: clitest
+
+      # Optional: add custom arguments to the clitest call
+      # args: [--first, --progress, none]
+
+      # Specify which files to test (as a regex)
+      files: ^docs/.*\.md$
+```
+
 ## GitHub Actions
 
 This repository doubles as a GitHub Action, so a workflow does not have to


### PR DESCRIPTION
By adding this YAML file to the repository, people now can run clitest
as a pre-commit hook.

> [!IMPORTANT]
> Only merge this when we're closer to the new version release. We must have an actual release tag so the example in the README works.